### PR TITLE
Add support for abstract enums

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "keywords": ["language", "module", "xp"],
   "require" : {
     "xp-framework/core": "^9.0 | ^8.0 | ^7.0",
-    "xp-framework/compiler": "^4.0",
+    "xp-framework/compiler": "^4.2",
     "php" : ">=5.6.0"
   },
   "require-dev" : {

--- a/src/main/php/lang/ast/syntax/php/EnumMembers.class.php
+++ b/src/main/php/lang/ast/syntax/php/EnumMembers.class.php
@@ -10,8 +10,8 @@ class EnumMembers extends Node {
     $this->line= $line;
   }
 
-  public function add($name, $ordinal) {
-    $this->members[$name]= [$ordinal];
+  public function add($name, $ordinal, $body) {
+    $this->members[$name]= [$ordinal, $body];
   }
 
   public function all() { return $this->members; }

--- a/src/main/php/lang/ast/syntax/php/Enums.class.php
+++ b/src/main/php/lang/ast/syntax/php/Enums.class.php
@@ -103,13 +103,11 @@ class Enums implements Extension {
 
       // Create static intializer and properties
       $init= clone $static;
-      $abstract= false;
       foreach ($node->members->all() as $name => $member) {
         $body[]= new Property(['public', 'static'], $name, null);
         $args= [new Literal($member[0]), new Literal("'".$name."'")];
 
         if ($member[1]) {
-          $abstract= true;
           $child= ['__static()' => clone $static] + $member[1];
           $member= new NewClassExpression(new ClassDeclaration([], null, $node->name, [], $child), $args);
         } else {
@@ -120,7 +118,7 @@ class Enums implements Extension {
       $body[]= $init;
 
       return new ClassDeclaration(
-        $abstract ? array_merge(['abstract'], $node->modifiers) : $node->modifiers,
+        $node->modifiers,
         $node->name,
         $node->parent ?: '\lang\Enum',
         $node->implements,

--- a/src/test/php/lang/ast/syntax/php/unittest/EnumsTest.class.php
+++ b/src/test/php/lang/ast/syntax/php/unittest/EnumsTest.class.php
@@ -48,7 +48,7 @@ class EnumsTest extends EmittingTest {
 
   #[@test]
   public function os_enum() {
-    $t= $this->type('enum <T> {
+    $t= $this->type('abstract enum <T> {
       WIN {
         public function root() { return "C:"; }
       },

--- a/src/test/php/lang/ast/syntax/php/unittest/EnumsTest.class.php
+++ b/src/test/php/lang/ast/syntax/php/unittest/EnumsTest.class.php
@@ -45,4 +45,20 @@ class EnumsTest extends EmittingTest {
       $t
     );
   }
+
+  #[@test]
+  public function os_enum() {
+    $t= $this->type('enum <T> {
+      WIN {
+        public function root() { return "C:"; }
+      },
+      UNIX {
+        public function root() { return "/"; }
+      };
+
+      public abstract function root();
+    }');
+
+    $this->assertEquals('C:', Enum::valueOf($t, 'WIN')->root());
+  }
 }


### PR DESCRIPTION
Example:

```php
abstract enum FileSystem {
  WIN {
    public function root() { return "C:"; }
  },
  UNIX {
    public function root() { return "/"; }
  };

  public abstract function root();
}

$root= FileSystem::$WIN->root(); // C:
```